### PR TITLE
Add `wDF` column for improved visualization of diffmaps in PyMOL

### DIFF
--- a/rsbooster/diffmaps/diffmap.py
+++ b/rsbooster/diffmaps/diffmap.py
@@ -105,6 +105,9 @@ def main():
     diff["Phi"] = ref.loc[common, "Phi"]
     diff.infer_mtz_dtypes(inplace=True)
 
+    # Useful for PyMOL
+    diff["wDF"] = (diff["DF"] * diff["W"]).astype("SFAmplitude")
+
     if args.dmax is None:
         diff.write_mtz(args.outfile)
     else:

--- a/rsbooster/diffmaps/internaldiffmap.py
+++ b/rsbooster/diffmaps/internaldiffmap.py
@@ -124,6 +124,9 @@ def main():
     internal["Phi"] = ref.loc[common, "Phi"]
     internal.infer_mtz_dtypes(inplace=True)
 
+    # Useful for PyMOL
+    internal["wDF"] = (internal["DF"] * internal["W"]).astype("SFAmplitude")
+
     if args.dmax is None:
         internal.write_mtz(args.outfile)
     else:


### PR DESCRIPTION
This PR adds an explicit column to difference maps that already has the weights column multiplied into the difference structure factor amplitudes. I have found this column, `wDF` to be helpful for rendering maps in PyMOL where for some reason I run into segfaults if I specify a separate weight column in `load_mtz`