### PR TITLE
Add automated testing to `rs-booster`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install rsbooster
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .
+        python -m pip install -e .[dev]
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
+    # Skip CI if 'skip ci' is contained in latest commit message
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    steps:
+
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install rsbooster
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+
+    - name: Test with pytest
+      run: |
+        python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [metadata]
 description_file = README.md
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = -n auto
+

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ PROJECT_URLS = {
     "Source Code": "https://github.com/Hekstra-Lab/rs-booster",
 }
 
+# Testing requirements
+tests_require = ["pytest", "pytest-xdist", "pytest-runner"]
 
 setup(
     name="rs-booster",
@@ -36,8 +38,7 @@ setup(
     project_urls=PROJECT_URLS,
     python_requires=">3.7",
     install_requires=["reciprocalspaceship", "matplotlib", "seaborn"],
-    setup_requires=["pytest-runner"],
-    tests_requires=["pytest", "pytest-xdist"],
+    extras_require={"dev": tests_require},
     entry_points={
         "console_scripts": [
             "rs.extrapolate=rsbooster.esf.extrapolate:main",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
     project_urls=PROJECT_URLS,
     python_requires=">3.7",
     install_requires=["reciprocalspaceship", "matplotlib", "seaborn"],
+    setup_requires=["pytest-runner"],
+    tests_requires=["pytest", "pytest-xdist"],
     entry_points={
         "console_scripts": [
             "rs.extrapolate=rsbooster.esf.extrapolate:main",

--- a/tests/test_rsbooster.py
+++ b/tests/test_rsbooster.py
@@ -1,0 +1,9 @@
+import rsbooster
+
+
+def test_version():
+    """
+    Test rsbooster.getVersionNumber() method exists and gives same result as
+    rsbooster.__version__
+    """
+    assert rsbooster.getVersionNumber() == rsbooster.__version__


### PR DESCRIPTION
Although I envision `rs-booster` being used to write commandline tools that are challenging to thoroughly test with automated unit tests, I also think it is good practice to have an automated test suite that will at least catch egregious errors. For example, it should at least be possible to `import rsbooster` if the package is installed. 

I also think it will be good practice to write applications in ways that can be tested thoroughly, and to then wrap the relevant functions with commandline interfaces to make them user-friendly. This PR is a step towards these goals.